### PR TITLE
Feat: Add child connection handling to replication

### DIFF
--- a/Atlas/NetworkDriver.cpp
+++ b/Atlas/NetworkDriver.cpp
@@ -193,6 +193,14 @@ int32 NetworkDriver::ServerReplicateActors(float DeltaSeconds)
 			Function->SendClientAdjustment(Connection->PlayerController);
 		}
 
+		for (int32 ChildIdx = 0; ChildIdx < Connection->Children.Num(); ChildIdx++)
+		{
+			if (Connection->Children[ChildIdx] && Connection->Children[ChildIdx]->PlayerController)
+			{
+				Function->SendClientAdjustment(Connection->Children[ChildIdx]->PlayerController);
+			}
+		}
+
 		for (FNetworkObjectInfo* ActorInfo : ConsiderList)
 		{
 			if (!ActorInfo || !ActorInfo->Actor)
@@ -201,11 +209,17 @@ int32 NetworkDriver::ServerReplicateActors(float DeltaSeconds)
 			}
 
 			AActor* Actor = ActorInfo->Actor;
-      
 			UActorChannel* Channel = FindChannelRef(Connection, Actor);
 
 			TArray<FNetViewer> ConnectionViewers;
 			ConnectionViewers.Add(CreateNetViewer(Connection));
+			for (int32 ChildIdx = 0; ChildIdx < Connection->Children.Num(); ChildIdx++)
+			{
+				if (Connection->Children[ChildIdx] && Connection->Children[ChildIdx]->ViewTarget)
+				{
+					ConnectionViewers.Add(CreateNetViewer(Connection->Children[ChildIdx]));
+				}
+			}
 
 			bool bIsRelevant = Actor->bAlwaysRelevant || IsActorRelevantToConnection(Actor, ConnectionViewers);
 


### PR DESCRIPTION
This commit updates the `ServerReplicateActors` function to properly handle child connections, which are typically used for split-screen players.

The changes include:
- Calling `SendClientAdjustment` for each child connection's player controller to ensure movement corrections are sent to all local players.
- Creating `FNetViewer`s for each child connection to ensure actor relevancy is calculated correctly from all viewpoints.

This should fix issues where secondary players in a split-screen session would experience movement issues or not see actors replicate correctly.